### PR TITLE
Deprecated field

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/lib/maxipago/request_builder/request.rb
+++ b/lib/maxipago/request_builder/request.rb
@@ -20,8 +20,8 @@ module Maxipago
       private
 
       def send_request(xml)
-        Rails.logger.info("=== SEND REQUEST")
-        Rails.logger.info(xml)
+        Rails.logger.info("=== SEND REQUEST") if defined?(Rails)
+        Rails.logger.info(xml) if defined?(Rails)
         set_uri
         set_http_session
 

--- a/lib/maxipago/xml_builder/builder_transaction.rb
+++ b/lib/maxipago/xml_builder/builder_transaction.rb
@@ -34,7 +34,6 @@ module Maxipago
                     xml.expMonth self.options[:exp_month]
                     xml.expYear self.options[:exp_year]
                     xml.cvvNumber self.options[:cvv_number] unless self.options[:cvv_number].nil?
-                    xml.eCommInd "eci"
                   }
                 }
               }
@@ -101,7 +100,6 @@ module Maxipago
                     xml.expMonth self.options[:exp_month]
                     xml.expYear self.options[:exp_year]
                     xml.cvvNumber self.options[:cvv_number] unless self.options[:cvv_number].nil?
-                    xml.eCommInd "eci"
                   }
                 }
               }
@@ -168,7 +166,6 @@ module Maxipago
                       xml.expMonth self.options[:exp_month]
                       xml.expYear self.options[:exp_year]
                       xml.cvvNumber self.options[:cvv_number] unless self.options[:cvv_number].nil?
-                      xml.eCommInd "eci"
                     }
                   }
                 }
@@ -259,7 +256,6 @@ module Maxipago
                         xml.expMonth self.options[:exp_month]
                         xml.expYear self.options[:exp_year]
                         xml.cvvNumber self.options[:cvv_number] unless self.options[:cvv_number].nil?
-                        xml.eCommInd "eci"
                       }
                     else
                       xml.onFile {
@@ -372,7 +368,6 @@ module Maxipago
                         xml.expMonth self.options[:exp_month]
                         xml.expYear self.options[:exp_year]
                         xml.cvvNumber self.options[:cvv_number] unless self.options[:cvv_number].nil?
-                        xml.eCommInd "eci"
                       }
                     else
                       xml.onFile {

--- a/spec/api_commands_spec.rb
+++ b/spec/api_commands_spec.rb
@@ -35,7 +35,7 @@ describe Maxipago::Client do
                     customer_id_ext: "1",
                     firstname: "Foo",
                     lastname: "Bar" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#add_customer (customer_id_ext not exists)" do
@@ -57,7 +57,7 @@ describe Maxipago::Client do
                     email: "foo@bar.com",
                     dob: "08/03/1980",
                     sex: "M" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#delete_consumer" do
@@ -68,7 +68,7 @@ describe Maxipago::Client do
       @mp.use(api)
       @mp.execute({ command: "delete_consumer",
                     customer_id: "1156" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#update_consumer (customer_id_ext not exists)" do
@@ -92,7 +92,7 @@ describe Maxipago::Client do
                     email: "foo@bar.com",
                     dob: "08/03/1980",
                     sex: "M" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#update_consumer (customer_id_ext exists)" do
@@ -115,7 +115,7 @@ describe Maxipago::Client do
                     email: "foo@bar.com",
                     dob: "08/03/1980",
                     sex: "M" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#add_card_onfile" do
@@ -142,7 +142,7 @@ describe Maxipago::Client do
                     onfile_permissions: "ongoing",
                     onfile_comment: "Cartao 1",
                     onfile_max_charge_amount: "500.00" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#delete_card_onfile" do
@@ -154,7 +154,7 @@ describe Maxipago::Client do
       @mp.execute({ command: "delete_card_onfile",
                     customer_id: "11008",
                     token: "5e3K+bwTdBg=" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#cancel_recurring" do
@@ -168,7 +168,7 @@ describe Maxipago::Client do
                     maxid: setup[:maxid],
                     apikey: setup[:apikey],
                     order_id: "0AF90437:013E8F9BAAA9:5A38:01849C5C" }) 
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -16,7 +16,7 @@ describe Maxipago::Client do
   end
 
   it "response should be nil" do
-    @mp.response.should eq(nil)
+    expect(@mp.response).to eq(nil)
   end
 
   it "executes a command raises an exception when request is nil" do

--- a/spec/rapi_commands_spec.rb
+++ b/spec/rapi_commands_spec.rb
@@ -29,7 +29,7 @@ describe Maxipago::Client do
       @mp.use(rapi)
       @mp.execute({ command: "one_transaction_report",
                     transaction_id: "530368" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#list_transactions_report" do
@@ -41,7 +41,7 @@ describe Maxipago::Client do
       @mp.execute({ command: "list_transactions_report",
                     period: "today",
                     pagesize: "1" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
   end
 end

--- a/spec/transaction_commands_spec.rb
+++ b/spec/transaction_commands_spec.rb
@@ -41,7 +41,7 @@ describe Maxipago::Client do
                     exp_year: setup[:exp_year],
                     cvv_number: setup[:cvv],
                     charge_total: "1.98" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#capture" do
@@ -54,7 +54,7 @@ describe Maxipago::Client do
                     order_id: "0AF90437:013E8F22A46F:94D9:01EC3389",
                     reference_num: "21312",
                     charge_total: "1.98" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#sale" do
@@ -73,7 +73,7 @@ describe Maxipago::Client do
                     exp_year: setup[:exp_year],
                     cvv_number: setup[:cvv],
                     charge_total: "2.99" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#sale (declined)" do
@@ -92,7 +92,7 @@ describe Maxipago::Client do
                     exp_year: setup[:exp_year],
                     cvv_number: setup[:cvv],
                     charge_total: "2.99" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#sale (fraud)" do
@@ -111,7 +111,7 @@ describe Maxipago::Client do
                     exp_year: setup[:exp_year],
                     cvv_number: setup[:cvv],
                     charge_total: "2.98" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#sale (fraud revision)" do
@@ -130,7 +130,7 @@ describe Maxipago::Client do
                     exp_year: setup[:exp_year],
                     cvv_number: setup[:cvv],
                     charge_total: "2.98" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#void" do
@@ -141,7 +141,7 @@ describe Maxipago::Client do
       @mp.use(transaction)
       @mp.execute({ command: "void",
                     transaction_id: "505107" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#reversal" do
@@ -154,7 +154,7 @@ describe Maxipago::Client do
                     order_id: "0AF90437:013E8F8BA24E:B68E:00DF7C9C",
                     reference_num: "21312",
                     charge_total: "10.00" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#recurring" do
@@ -176,7 +176,7 @@ describe Maxipago::Client do
                     frequency: "1",
                     installments: "5",
                     failure_threshold: "1" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#bank_bill" do
@@ -199,7 +199,7 @@ describe Maxipago::Client do
                     expiration_date: "2013-05-15",
                     number: "10000001",
                     charge_total: "10.00" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#bank_bill (exists)" do
@@ -222,7 +222,7 @@ describe Maxipago::Client do
                     expiration_date: "2013-05-15",
                     number: "10000000",
                     charge_total: "10.00" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#online_debit" do
@@ -245,7 +245,7 @@ describe Maxipago::Client do
                     billing_email: "foo@bar.com",
                     parameters_url: "id=123456&tp=3",
                     charge_total: "10.00" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#sale (token)" do
@@ -260,7 +260,7 @@ describe Maxipago::Client do
                     customer_id: "12837",
                     token: "Fmj2jBtkxG0=",
                     charge_total: "10.00" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#recurring (token)" do
@@ -280,7 +280,7 @@ describe Maxipago::Client do
                     frequency: "1",
                     installments: "5",
                     failure_threshold: "1" })
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
 
     it "#save_on_file" do
@@ -308,7 +308,7 @@ describe Maxipago::Client do
                     onfile_end_date: "12/25/2020",
                     charge_total: "10.00" })
 
-      @mp.response[:body].should eq(body)
+      expect(@mp.response[:body]).to eq(body)
     end
   end
 end


### PR DESCRIPTION
Remove deprecated 'eCommInd' field, according to maxiPago! support for achieve a valid transaction in production.